### PR TITLE
Sync typo

### DIFF
--- a/src/js/components/labbook/branchMenu/BranchMenu.js
+++ b/src/js/components/labbook/branchMenu/BranchMenu.js
@@ -825,7 +825,7 @@ export default class BranchMenu extends Component {
                   </div>
 
                   <div className="BranchMenu__button-menu">
-                    Synching is disabled for example projects.
+                    Syncing is disabled for example projects.
                   </div>
 
                 </Fragment>


### PR DESCRIPTION
removed h from sync in tooltip message