### PR TITLE
Sprint 33 bugfixes (GIG - 2171, 2141, 2142, 2040, 2120, 2144, 2133 )

### DIFF
--- a/__tests__/components/dashboard/DashboardLocal.test.js
+++ b/__tests__/components/dashboard/DashboardLocal.test.js
@@ -5,6 +5,7 @@ import history from 'JS/history'
 import {mount} from 'enzyme'
 import LocalLabbooksContainer from 'Components/dashboard/labbooks/localLabbooks/LocalLabbooksContainer';
 import store from "JS/redux/store"
+import {BrowserRouter as Router} from 'react-router-dom'
 
 import json from './__relaydata__/DashboardLocal.json'
 
@@ -29,7 +30,9 @@ test('Test DashboardLocal snapshot', () => {
 
       relayTestingUtils.relayWrap(
         <Provider store={store}>
-          <LocalLabbooksContainer {...fixtures} />
+          <Router>
+            <LocalLabbooksContainer {...fixtures} />
+          </Router>
         </Provider>
       , {}, json.data)
 

--- a/__tests__/components/dashboard/__snapshots__/DashboardLocal.test.js.snap
+++ b/__tests__/components/dashboard/__snapshots__/DashboardLocal.test.js.snap
@@ -296,8 +296,9 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="hidden"
         />
       </div>
-      <div
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/zab"
         onClick={[Function]}
       >
         <div
@@ -355,9 +356,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/untracked-labbook"
         onClick={[Function]}
       >
         <div
@@ -415,9 +417,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/untracked-2"
         onClick={[Function]}
       >
         <div
@@ -475,9 +478,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/untracked"
         onClick={[Function]}
       >
         <div
@@ -535,9 +539,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/dmk/trump-tweets"
         onClick={[Function]}
       >
         <div
@@ -602,9 +607,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/tracking-endabled"
         onClick={[Function]}
       >
         <div
@@ -662,9 +668,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/tracked-2"
         onClick={[Function]}
       >
         <div
@@ -722,9 +729,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/tpub"
         onClick={[Function]}
       >
         <div
@@ -782,9 +790,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/thisiasdmadskadssfdkjjssdfs-jasjdasj"
         onClick={[Function]}
       >
         <div
@@ -842,9 +851,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/dmk/testing-notifications"
         onClick={[Function]}
       >
         <div
@@ -909,9 +919,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/testing-activity-feed"
         onClick={[Function]}
       >
         <div
@@ -976,9 +987,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-uploader-1"
         onClick={[Function]}
       >
         <div
@@ -1043,9 +1055,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/dmk/test-lb"
         onClick={[Function]}
       >
         <div
@@ -1110,9 +1123,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-labbook"
         onClick={[Function]}
       >
         <div
@@ -1177,9 +1191,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-building-status-2"
         onClick={[Function]}
       >
         <div
@@ -1237,9 +1252,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-building-state"
         onClick={[Function]}
       >
         <div
@@ -1297,9 +1313,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-building-6"
         onClick={[Function]}
       >
         <div
@@ -1357,9 +1374,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-building-5"
         onClick={[Function]}
       >
         <div
@@ -1417,9 +1435,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-building-4"
         onClick={[Function]}
       >
         <div
@@ -1477,9 +1496,10 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
-      <div
+      </a>
+      <a
         className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+        href="/projects/cbutler/test-building-3"
         onClick={[Function]}
       >
         <div
@@ -1537,7 +1557,7 @@ exports[`Test DashboardLocal snapshot 1`] = `
           className="Tooltip LocalLabbookPanel__loading"
           data-tooltip="loading"
         />
-      </div>
+      </a>
       <div
         className="Labbook__loader-hidden"
       >

--- a/__tests__/components/dashboard/dashboard.test.js
+++ b/__tests__/components/dashboard/dashboard.test.js
@@ -6,6 +6,7 @@ import {StaticRouter, Link} from 'react-router';
 import {Provider} from 'react-redux'
 import Dashboard from 'Components/dashboard/Dashboard';
 import history from 'JS/history';
+import {BrowserRouter as Router} from 'react-router-dom'
 //store
 import store from "JS/redux/store"
 
@@ -15,7 +16,9 @@ test('Test Dashboard datasets', () => {
 
   const dashboard = renderer.create(
     <Provider store={store}>
-      <Dashboard match={{params: {id: 'datasets'}}} history={history}/>
+      <Router>
+        <Dashboard match={{params: {id: 'datasets'}}} history={history}/>
+      </Router>
     </Provider>
 
   );
@@ -27,7 +30,9 @@ test('Test Dashboard datasets', () => {
 test('Test Dashboard Labbooks', () => {
   const dashboard = renderer.create(
     <Provider store={store}>
-      <Dashboard match={{params: {id: 'labbbooks'}}} history={history}/>
+      <Router>
+        <Dashboard match={{params: {id: 'labbbooks'}}} history={history}/>
+      </Router>
     </Provider>
   );
   let tree = dashboard.toJSON();

--- a/__tests__/components/dashboard/labbooks/localLabbooks/LocalLabbookPanel.test.js
+++ b/__tests__/components/dashboard/labbooks/localLabbooks/LocalLabbookPanel.test.js
@@ -8,6 +8,7 @@ import LocalLabbookPanel from 'Components/dashboard/labbooks/localLabbooks/Local
 import relayTestingUtils from 'relay-testing-utils'
 import {MemoryRouter } from 'react-router-dom'
 import environment from 'JS/createRelayEnvironment'
+import {BrowserRouter as Router} from 'react-router-dom'
 
 const variables = {first:5}
 const goToLabbook = () =>{
@@ -29,9 +30,11 @@ test('Test LocalLabbooks rendering', () => {
   const localLabbooks = renderer.create(
 
      relayTestingUtils.relayWrap(
-       <LocalLabbookPanel
-         {...fixtures}
-       />, {}, json.data.labbookList.localLabbooks.edges[0])
+      <Router>
+        <LocalLabbookPanel
+          {...fixtures}
+        />
+      </Router>, {}, json.data.labbookList.localLabbooks.edges[0])
 
   );
 

--- a/__tests__/components/dashboard/labbooks/localLabbooks/LocalLabbooks.test.js
+++ b/__tests__/components/dashboard/labbooks/localLabbooks/LocalLabbooks.test.js
@@ -11,6 +11,7 @@ import {MemoryRouter } from 'react-router-dom'
 import environment from 'JS/createRelayEnvironment'
 import {Provider} from 'react-redux'
 import store from 'JS/redux/store'
+import {BrowserRouter as Router} from 'react-router-dom'
 
 import Adapter from 'enzyme-adapter-react-16';
 
@@ -95,13 +96,15 @@ describe('LocalLabbooks', () => {
     const localLabbooksSnap = renderer.create(
 
        relayTestingUtils.relayWrap(
-         <Provider store={store}>
-          <LocalLabbooks
+        <Provider store={store}>
+          <Router>
+            <LocalLabbooks
 
-           {...fixtures}
+              {...fixtures}
 
-          />
-          </Provider>, {}, json.data.labbookList)
+            />
+          </Router>
+        </Provider>, {}, json.data.labbookList)
 
     )
 
@@ -120,7 +123,9 @@ describe('LocalLabbooks', () => {
    *****/
   const localLabbooksShallow = mount(
     <Provider store={store}>
-     <LocalLabbooks history={history} {...fixtures} feed={json.data}/>
+     <Router>
+      <LocalLabbooks history={history} {...fixtures} feed={json.data}/>
+     </Router>
     </Provider>
 
   );
@@ -129,7 +134,7 @@ describe('LocalLabbooks', () => {
   it('LocalLabbooks panel length', () => {
 
 
-    expect(localLabbooksShallow.find('.LocalLabbooks__panel')).toHaveLength(11)
+    expect(localLabbooksShallow.find('.LocalLabbooks__panel')).toHaveLength(16)
   })
 
 
@@ -148,13 +153,15 @@ describe('LocalLabbooks', () => {
   const localLabbooksMount = mount(
     relayTestingUtils.relayWrap(
       <Provider store={store}>
-       <LocalLabbooks
-         {...fixtures}
-         showModal={showModalTest}
-         goToLabbook={goToLabbookTest}
-         sortProcessed={sortProcessedTest}
-         relay={{loadMore: loadMore}}
-       />
+        <Router>
+          <LocalLabbooks
+            {...fixtures}
+            showModal={showModalTest}
+            goToLabbook={goToLabbookTest}
+            sortProcessed={sortProcessedTest}
+            relay={{loadMore: loadMore}}
+          />
+       </Router>
       </Provider>, {}, json.data.labbookList
      )
   );

--- a/__tests__/components/dashboard/labbooks/localLabbooks/__snapshots__/LocalLabbookPanel.test.js.snap
+++ b/__tests__/components/dashboard/labbooks/localLabbooks/__snapshots__/LocalLabbookPanel.test.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Test LocalLabbooks rendering 1`] = `
-<div
+<a
   className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+  href="/projects/cbutler/zab"
   onClick={[Function]}
 >
   <div
@@ -60,5 +61,5 @@ exports[`Test LocalLabbooks rendering 1`] = `
     className="Tooltip LocalLabbookPanel__undefined"
     data-tooltip="undefined"
   />
-</div>
+</a>
 `;

--- a/__tests__/components/dashboard/labbooks/localLabbooks/__snapshots__/LocalLabbooks.test.js.snap
+++ b/__tests__/components/dashboard/labbooks/localLabbooks/__snapshots__/LocalLabbooks.test.js.snap
@@ -111,8 +111,9 @@ exports[`LocalLabbooks LocalLabbooks snapshot 1`] = `
         className="hidden"
       />
     </div>
-    <div
+    <a
       className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+      href="/projects/cbutler/zab"
       onClick={[Function]}
     >
       <div
@@ -170,9 +171,10 @@ exports[`LocalLabbooks LocalLabbooks snapshot 1`] = `
         className="Tooltip LocalLabbookPanel__loading"
         data-tooltip="loading"
       />
-    </div>
-    <div
+    </a>
+    <a
       className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+      href="/projects/cbutler/untracked-labbook"
       onClick={[Function]}
     >
       <div
@@ -230,9 +232,10 @@ exports[`LocalLabbooks LocalLabbooks snapshot 1`] = `
         className="Tooltip LocalLabbookPanel__loading"
         data-tooltip="loading"
       />
-    </div>
-    <div
+    </a>
+    <a
       className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+      href="/projects/cbutler/untracked-2"
       onClick={[Function]}
     >
       <div
@@ -290,9 +293,10 @@ exports[`LocalLabbooks LocalLabbooks snapshot 1`] = `
         className="Tooltip LocalLabbookPanel__loading"
         data-tooltip="loading"
       />
-    </div>
-    <div
+    </a>
+    <a
       className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+      href="/projects/cbutler/untracked"
       onClick={[Function]}
     >
       <div
@@ -350,9 +354,10 @@ exports[`LocalLabbooks LocalLabbooks snapshot 1`] = `
         className="Tooltip LocalLabbookPanel__loading"
         data-tooltip="loading"
       />
-    </div>
-    <div
+    </a>
+    <a
       className="LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between"
+      href="/projects/dmk/trump-tweets"
       onClick={[Function]}
     >
       <div
@@ -417,7 +422,7 @@ exports[`LocalLabbooks LocalLabbooks snapshot 1`] = `
         className="Tooltip LocalLabbookPanel__loading"
         data-tooltip="loading"
       />
-    </div>
+    </a>
     <div
       className="Labbook__loader-hidden"
     >

--- a/src/css/components/dashboard/localLabBooks.scss
+++ b/src/css/components/dashboard/localLabBooks.scss
@@ -215,7 +215,7 @@
   text-align: center;
   word-break: break-all;
 
-  color: $jet;
+  color: $jet !important;
   background: $white;
   background-size: 50px;
 
@@ -232,7 +232,7 @@
 
 .LocalLabbooks__panel:hover {
   transition: box-shadow 0.5s;
-
+  text-decoration: none;
   box-shadow: 0 0px 12px 0 rgba(0,0,0,.50);
 }
 

--- a/src/css/components/labbook/branchMenu.scss
+++ b/src/css/components/labbook/branchMenu.scss
@@ -174,16 +174,6 @@
 
 }
 
-.BranchMenu__item--export--downloading {
-  @extend .BranchMenu__item;
-  background: url('./../images/icons/rings.svg') no-repeat 7px center;
-  background-size: 24px;
-}
-.BranchMenu__item--export--downloading:hover {
-  background: $background-color url('./../images/icons/rings.svg') no-repeat 7px center;
-  background-size: 24px;
-}
-
 .BranchMenu__item--delete{
   @extend .BranchMenu__item;
   background: url('./../images/icons/trash.svg') no-repeat 11px center;
@@ -238,7 +228,8 @@
 
 
 .BranchMenu__item--flat-button,
-.BranchMenu__item--flat-button:focus {
+.BranchMenu__item--flat-button:focus,
+.BranchMenu__item--flat-button:disabled, {
   width: 100%;
   cursor: pointer;
   margin: 1.5px 0;

--- a/src/css/components/labbook/containerStatus.scss
+++ b/src/css/components/labbook/containerStatus.scss
@@ -93,6 +93,7 @@
   border: 3px solid $goldenLemon;
   background-size: 20px;
 }
+
 .ContainerStatus__container-state.Stopped {
   background: $background-color url('./../images/icons/stop.svg') no-repeat 90% center;
   border: 3px solid $romanSilver;
@@ -108,6 +109,19 @@
   background-size: 20px;
   margin: 0 -7px -1px 0;
   line-height: 31px;
+}
+
+.ContainerStatus__container-state.LookingUp {
+  width: 141px !important;
+  height: 31px !important;
+  font-size: 16px !important;
+  line-height: 26px !important;
+  margin: 0 !important;
+  box-shadow: none !important;
+  background: $background-color url('./../images/loaders/button-starting.svg') no-repeat 90% center !important;
+  border: 3px solid $goldenLemon !important;
+  background-size: 20px !important;
+  cursor: auto;
 }
 
 .ContainerStatus__container-state.Rebuild{

--- a/src/css/components/labbook/favorite.scss
+++ b/src/css/components/labbook/favorite.scss
@@ -53,6 +53,9 @@
   right: 20px;
 }
 .Favorite__description-section{
+  max-height: 80px;
+  word-break: break-all;
+  overflow: hidden;
     p{
       margin: 0;
     }

--- a/src/css/components/labbook/overview/overview.scss
+++ b/src/css/components/labbook/overview/overview.scss
@@ -227,9 +227,17 @@
     font-family: FontAwesome !important;
   }
   .Overview__readme--editing-buttons {
+    position: relative;
     @include flex(center, row);
     button {
       margin: 0 10px;
+    }
+    .BranchMenu__menu-pointer{
+      right: auto;
+      margin-left: -55px;
+    }
+    .BranchMenu__button-menu{
+      right: auto;
     }
   }
 }

--- a/src/css/components/shared/user.scss
+++ b/src/css/components/shared/user.scss
@@ -42,21 +42,22 @@
   width: 100px;
   padding: 5px;
   border-radius: 8px;
+  @include flex(space-between, column)
 }
 
 
 .User__button {
-  width: 100%;
   align-self: center;
   color: $white;
   border-radius: 0px;
   padding: 5px;
   background-color: transparent !important;
   border-width: 0px;
-
+  font-weight: 100;
 }
 
 .User__button:hover {
+  text-decoration: none;
   color: $turquise;
   border-width: 0px;
 }

--- a/src/js/components/dashboard/labbooks/Labbooks.js
+++ b/src/js/components/dashboard/labbooks/Labbooks.js
@@ -162,7 +162,7 @@ class Labbooks extends Component {
   */
   _goToLabbook = (labbookName, owner) => {
     this.setState({'labbookName': labbookName, 'owner': owner})
-    this.props.history.replace(`/projects/${owner}/${labbookName}`)
+    // this.props.history.replace(`/projects/${owner}/${labbookName}`)
   }
 
 

--- a/src/js/components/dashboard/labbooks/Labbooks.js
+++ b/src/js/components/dashboard/labbooks/Labbooks.js
@@ -162,7 +162,6 @@ class Labbooks extends Component {
   */
   _goToLabbook = (labbookName, owner) => {
     this.setState({'labbookName': labbookName, 'owner': owner})
-    // this.props.history.replace(`/projects/${owner}/${labbookName}`)
   }
 
 

--- a/src/js/components/dashboard/labbooks/localLabbooks/LocalLabbookPanel.js
+++ b/src/js/components/dashboard/labbooks/localLabbooks/LocalLabbookPanel.js
@@ -1,6 +1,7 @@
 //vendor
 import React, { Component } from 'react'
 import Highlighter from 'react-highlight-words'
+import {Link} from 'react-router-dom'
 //muations
 import StartContainerMutation from 'Mutations/StartContainerMutation'
 import StopContainerMutation from 'Mutations/StopContainerMutation'
@@ -224,7 +225,8 @@ export default class LocalLabbookPanel extends Component {
 
 
     return (
-      <div
+      <Link
+        to={`/projects/${edge.node.owner}/${edge.node.name}`}
         onClick={() => this.props.goToLabbook(edge.node.name, edge.node.owner)}
         key={'local' + edge.node.name}
         className='LocalLabbooks__panel column-4-span-3 flex flex--column justify--space-between'>
@@ -288,6 +290,6 @@ export default class LocalLabbookPanel extends Component {
             className={`Tooltip LocalLabbookPanel__${this.props.visibility}`}>
           </div>
         }
-    </div>)
+    </Link>)
   }
 }

--- a/src/js/components/labbook/Labbook.js
+++ b/src/js/components/labbook/Labbook.js
@@ -453,6 +453,7 @@ class Labbook extends Component {
                      setSyncingState={this._setSyncingState}
                      setPublishingState={this._setPublishingState}
                      setExportingState={this._setExportingState}
+                     isExporting={this.props.isExporting}
                      toggleBranchesView={this._toggleBranchesView}
                      isMainWorkspace={name === 'workspace' || name === `gm.workspace-${localStorage.getItem('username')}`}
                      auth={this.props.auth}

--- a/src/js/components/labbook/Labbook.js
+++ b/src/js/components/labbook/Labbook.js
@@ -521,6 +521,8 @@ class Labbook extends Component {
                           labbookId={labbook.id}
                           setBuildingState={this._setBuildingState}
                           readme={labbook.readme}
+                          isSyncing={this.props.isSyncing}
+                          isPublishing={this.props.isPublishing}
                         />)
                       }}
                     />
@@ -534,7 +536,11 @@ class Labbook extends Component {
                               key={this.props.labbookName + '_overview'}
                               labbook={labbook}
                               description={labbook.description}
+                              labbookId={labbook.id}
+                              setBuildingState={this._setBuildingState}
                               readme={labbook.readme}
+                              isSyncing={this.props.isSyncing}
+                              isPublishing={this.props.isPublishing}
                             />)
                           }}
                         />

--- a/src/js/components/labbook/containerStatus/ContainerStatus.js
+++ b/src/js/components/labbook/containerStatus/ContainerStatus.js
@@ -342,7 +342,7 @@ class ContainerStatus extends Component {
    */
   _containerAction(status, evt){
 
-    if(!store.getState().labbook.isBuilding){
+    if(!store.getState().labbook.isBuilding && !this.props.isLookingUpPackages){
       if(status === "Stop"){
 
         this.setState({
@@ -402,7 +402,7 @@ class ContainerStatus extends Component {
     let newStatus = status
 
     newStatus = this.state.isMouseOver && (status === 'Running') ? 'Stop' : newStatus
-    newStatus = this.state.isMouseOver && (status === 'Stopped') ? 'Run' : newStatus
+    newStatus = this.state.isMouseOver && (status === 'Stopped' && !this.props.isLookingUpPackages) ? 'Run' : newStatus
     newStatus = this.state.isMouseOver && (status === 'Rebuild') ? 'Rebuild' : newStatus
     newStatus = this.state.isMouseOver && (status === 'Rebuild') ? 'Rebuild' : newStatus
 
@@ -472,6 +472,7 @@ class ContainerStatus extends Component {
       'Building': this.props.isBuilding || this.props.imageStatus === 'BUILD_IN_PROGRESS',
       'Syncing': this.props.isSyncing,
       'Publishing': this.props.isPublishing,
+      'LookingUp': this.props.isLookingUpPackages,
       'ContainerStatus__container-state--expanded': this.state.isMouseOver && notExcluded && !this.props.isBuilding && !(this.props.imageStatus === 'BUILD_IN_PROGRESS') ,
       'ContainerStatus__container-remove-pointer': !notExcluded || this.props.isBuilding || (this.props.imageStatus === 'BUILD_IN_PROGRESS') || this.state.isSyncing ||this.state.isPublishing
     })
@@ -586,7 +587,7 @@ class ContainerStatus extends Component {
 const mapStateToProps = (state, ownProps) => {
   return {
     containerMenuOpen: state.containerStatus.containerMenuOpen,
-
+    isLookingUpPackages: state.containerStatus.isLookingUpPackages
   }
 }
 

--- a/src/js/components/labbook/containerStatus/ContainerStatus.js
+++ b/src/js/components/labbook/containerStatus/ContainerStatus.js
@@ -469,12 +469,12 @@ class ContainerStatus extends Component {
       'ContainerStatus__container-state--menu-open': this.props.containerMenuOpen,
       'ContainerStatus__container-state': !this.props.containerMenuOpen,
       [status]: !this.props.isBuilding && !this.props.isSyncing && !this.props.isPublishing,
-      'Building': this.props.isBuilding || this.props.imageStatus === 'BUILD_IN_PROGRESS',
+      'Building': this.props.isBuilding || this.state.imageStatus === 'BUILD_IN_PROGRESS',
       'Syncing': this.props.isSyncing,
       'Publishing': this.props.isPublishing,
       'LookingUp': this.props.isLookingUpPackages,
-      'ContainerStatus__container-state--expanded': this.state.isMouseOver && notExcluded && !this.props.isBuilding && !(this.props.imageStatus === 'BUILD_IN_PROGRESS') ,
-      'ContainerStatus__container-remove-pointer': !notExcluded || this.props.isBuilding || (this.props.imageStatus === 'BUILD_IN_PROGRESS') || this.state.isSyncing ||this.state.isPublishing
+      'ContainerStatus__container-state--expanded': this.state.isMouseOver && notExcluded && !this.props.isBuilding && !(this.state.imageStatus === 'BUILD_IN_PROGRESS') ,
+      'ContainerStatus__container-remove-pointer': !notExcluded || this.props.isBuilding || (this.state.imageStatus === 'BUILD_IN_PROGRESS') || this.state.isSyncing ||this.state.isPublishing
     })
 
     const containerMenuIconCSS = classNames({

--- a/src/js/components/labbook/environment/PackageDependencies.js
+++ b/src/js/components/labbook/environment/PackageDependencies.js
@@ -23,6 +23,7 @@ import {
 import { setErrorMessage, setWarningMessage } from 'JS/redux/reducers/footer'
 import { setContainerMenuWarningMessage} from 'JS/redux/reducers/labbook/environment/environment'
 import { setBuildingState} from 'JS/redux/reducers/labbook/labbook'
+import { setLookingUpPackagesState} from 'JS/redux/reducers/labbook/containerStatus'
 //Mutations
 import AddPackageComponentsMutation from 'Mutations/environment/AddPackageComponentsMutation'
 import RemovePackageComponentsMutation from 'Mutations/environment/RemovePackageComponentsMutation'
@@ -415,10 +416,11 @@ class PackageDependencies extends Component {
       disableInstall: true,
       installDependenciesButtonState: 'loading'
     })
+
     this.props.setBuildingState(true)
-
+    this.props.setLookingUpPackagesState(true)
     PackageLookup.query(labbookName, owner, filteredInput).then((response)=>{
-
+      this.props.setLookingUpPackagesState(false)
       if(response.errors){
         packages = packages.map((pkg) => {
           pkg.validity = 'valid'
@@ -429,7 +431,9 @@ class PackageDependencies extends Component {
           self.setState({installDependenciesButtonState: ''})
         }, 2000)
         this.props.setErrorMessage(`Error occured looking up packages`, response.errors)
+
         this.props.setBuildingState(false)
+
       } else{
         let resPackages = response.data.labbook.packages;
         let invalidCount = 0;
@@ -931,6 +935,7 @@ const mapDispatchToProps = dispatch => {
       setContainerMenuWarningMessage,
       setBuildingState,
       setWarningMessage,
+      setLookingUpPackagesState,
   }
 }
 

--- a/src/js/components/shared/User.js
+++ b/src/js/components/shared/User.js
@@ -38,7 +38,7 @@ export default class User extends Component {
       handles click to update state
     */
   _handleClickOutside(event) {
-    const userElementIds = ['user', 'username', 'logout']
+    const userElementIds = ['user', 'username', 'logout', 'profile']
     if(this.state.dropdownVisible && (userElementIds.indexOf(event.target.id) < 0)){
       this.setState({
         dropdownVisible: false
@@ -74,6 +74,15 @@ export default class User extends Component {
         <div className={ this.state.dropdownVisible ? 'User__dropdown--arrow' : 'hidden'}></div>
 
         <div className={this.state.dropdownVisible ? 'User__dropdown' : 'hidden'}>
+          <a
+            id="profile"
+            href="http://gigantum.com/profile"
+            rel="noopener noreferrer"
+            target="_blank"
+            className="User__button"
+          >
+            Profile
+          </a>
           <button
             id="logout"
             className="User__button btn-margin"

--- a/src/js/redux/reducers/labbook/containerStatus.js
+++ b/src/js/redux/reducers/labbook/containerStatus.js
@@ -6,6 +6,7 @@ import dispatcher from 'JS/redux/dispatcher'
 export const UPDATE_CONTAINER_STATUS = 'UPDATE_CONTAINER_STATUS'
 export const RESET_DETAIL_STORE = 'RESET_DETAIL_STORE'
 export const UPDATE_CONTAINER_MENU_VISIBILITY = 'UPDATE_CONTAINER_MENU_VISIBILITY'
+export const IS_LOOKING_UP_PACKAGES = 'IS_LOOKING_UP_PACKAGES'
 
 /**
  * actions
@@ -13,11 +14,13 @@ export const UPDATE_CONTAINER_MENU_VISIBILITY = 'UPDATE_CONTAINER_MENU_VISIBILIT
 
 export const setContainerStatus = (status) => dispatcher(UPDATE_CONTAINER_STATUS, {status})
 export const setContainerMenuVisibility = (containerMenuOpen) => dispatcher(UPDATE_CONTAINER_MENU_VISIBILITY, {containerMenuOpen})
+export const setLookingUpPackagesState = (isLookingUpPackages) => dispatcher(IS_LOOKING_UP_PACKAGES, {isLookingUpPackages})
 
 export default (
  state = {
    'status': "",
    'containerMenuOpen': false,
+   'isLookingUpPackages': false,
  },
  action
 ) => {
@@ -38,7 +41,12 @@ if (action.type === UPDATE_CONTAINER_STATUS) {
      ...state,
      detailMode: false
    };
- }
+ } else if(action.type === IS_LOOKING_UP_PACKAGES){
+  return {
+    ...state,
+    isLookingUpPackages: action.payload.isLookingUpPackages
+  };
+}
 
  return state;
 };


### PR DESCRIPTION
- Favorite card description text will no longer overflow
- Publish/Syncing is blocked on export
- Fixed styling of export button while exporting
- Container can no longer be started while looking up packages
- Editing readme disabled while publishing/syncing
- Project listings changed from div to a tag so they can be right click and opened in new tab
- Added profile link to saas profile page on sidebar
- fixed bug causing imagestatus not to update